### PR TITLE
Add note about job groups.

### DIFF
--- a/content/openqa/openqa-cli-cheatsheet.md
+++ b/content/openqa/openqa-cli-cheatsheet.md
@@ -44,6 +44,10 @@ Restart a job but not its [directly chained parents](http://open.qa/docs/#_notes
 
 This is often referred to as "isos post" because it has been used to [test an ISO image](http://open.qa/docs/#_adding_a_new_iso_to_test). Nowadays we are also testing non-iso images
 
+If you need to limit it to a certain job group (e.g. `1` or `openSUSE Tumbleweed `) use e.g. `_GROUP_ID=1` for selecting the job group by id or `_GROUP="openSUSE Tumbleweed"` to select it by name.
+
+See also [open.qa/docs](https://open.qa/docs/#_spawning_multiple_jobs_based_on_templates_isos_post) for a listing of possible scheduling parameters.
+
 ### Post a new job with `json` parameters
 
 To post a job with settings from a `json` file

--- a/content/posts/2023/2023-02-23-Safely_clone_a_job_on_a_production_instance.md
+++ b/content/posts/2023/2023-02-23-Safely_clone_a_job_on_a_production_instance.md
@@ -19,11 +19,11 @@ However there are situations, in which you can't do everything on your own insta
 Use `openqa-clone-custom-git-refspec`, which already takes care of those things for you. Or:
 
 ```
-openqa-clone-job ... _GROUP=0 [BUILD=wuseldusel] [TEST=wuseldusel]
-openqa-clone-job ... _GROUP=0 {TEST,BUILD}+=-phoenix-poo123456
+openqa-clone-job ... _GROUP_ID=0 [BUILD=wuseldusel] [TEST=wuseldusel]
+openqa-clone-job ... _GROUP_ID=0 {TEST,BUILD}+=-phoenix-poo123456
 ```
 
-`_GROUP=0` is obligatory, `BUILD` and `TEST` are optional. If you don't set them, the cloned job will stil show up in the Next/Previous job list.
+`_GROUP_ID=0` is obligatory, `BUILD` and `TEST` are optional but if you don't set them, the cloned job will show up in the Next/Previous job list.
 
 Change or remove `PUBLISH_HDD_x` variables, if present, to avoid asset overwrite.
 


### PR DESCRIPTION
Add a note that documents how to limit an isos post to a specific job group. This is a common pitfall because it's not always clear which permutation of `GROUP` is being used.